### PR TITLE
feat: add notification priority

### DIFF
--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -343,6 +343,10 @@ Push.Configure = function(options) {
                 data: data
             });
 
+            if (typeof notification.priority !== 'undefined') {
+              message.priority = notification.priority;
+            }
+
             if (Push.debug) {
               console.log('Create GCM Sender using "' + options.gcm.apiKey + '"');
             }


### PR DESCRIPTION
add notification priority for FCM

we're currently sending 'data' messages which include no service-level objective to be delivered. RocketChat should send notifications with priority '10'. this change adds the possibility

https://firebase.google.com/docs/cloud-messaging/http-server-ref