### PR TITLE
Group iOS Notifications

### DIFF
--- a/lib/server/push.api.js
+++ b/lib/server/push.api.js
@@ -217,6 +217,11 @@ Push.Configure = function(options) {
 
             if (typeof notification.title !== 'undefined') {
               note.alert.title = notification.title;
+              note.alert['summary-arg'] = notification.title;
+            }
+
+            if (typeof notification.notId !== 'undefined') {
+              note['thread-id'] = notification.notId;
             }
 
             // Allow the user to set payload data


### PR DESCRIPTION
### Why?
On iOS APNS notifications are grouped by `thread-id` identifier, we have `notId`, an identifier of `host + rid` and will use this to group notifications by room.
The `summary-arg` attribute will used with summary `count + more notifications from + summary-arg`.
You can read more here: [Grouped notifications iOS](https://medium.com/swift-india/lets-take-quick-dive-in-grouped-notifications-5d41af9d6463)

### How to test
You need a iOS device and Rocket.Chat installed.
- [ ] Receive more than one notification from same room.
- [ ] This notifications should be grouped like this:
![GroupedNotifications](https://user-images.githubusercontent.com/29778115/70833789-62bdc700-1dd7-11ea-83f1-913316a2939d.png)